### PR TITLE
Minor filename change in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Step A: Run below
 ```
     cd ~/catkin_point_lio_unilidar
     source install/setup.bash
-    ros2 launch point_lio mapping_unilidar_l1.py
+    ros2 launch point_lio mapping_unilidar_l1.launch.py
 ```
 
 Step B: Run LiDAR's ros driver or play rosbag.


### PR DESCRIPTION
Error in ROS2 Humble with the current path (pointing to `catkin_point_lio_unilidar/install/point_lio/share/point_lio/launch/mapping_unilidar_l1.py` ) returns:

```
file 'mapping_unilidar_l1.py' was not found in the share directory of package 'point_lio' which is at '/home/admin/catkin_point_lio_unilidar/install/point_lio/share/point_lio'
``` 