### PR TITLE
Fix directory path in README for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For using lidar `L2`, you should download and build [unilidar_sdk2](https://gith
 ```bash
 git clone https://github.com/unitreerobotics/unilidar_sdk2.git
 
-cd unilidar_sdk/unitree_lidar_ros2
+cd unilidar_sdk2/unitree_lidar_ros2
 
 colcon build
 ```


### PR DESCRIPTION
correct directory for unilidar_sdk2 is unilidar_sdk2/unitree_lidar_ros2

 ```
git clone https://github.com/unitreerobotics/unilidar_sdk2.glidar_sdk2.git
Cloning into 'unilidar_sdk2'...
remote: Enumerating objects: 229, done.
remote: Counting objects: 100% (15/15), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 229 (delta 11), reused 10 (delta 10), pack-reused 214 (from 1)
Receiving objects: 100% (229/229), 1.23 MiB | 12.49 MiB/s, done.
Resolving deltas: 100% (110/110), done.
% cd unilidar_sdk/unitree_lidar_ros2
cd: no such file or directory: unilidar_sdk/unitree_lidar_ros2

% ls ~/ros2_humble/ros2-linux/unilidar_sdk2
docs                    README_CN.md            unitree_lidar_ros2      VERSION.md
LICENSE                 README.md               unitree_lidar_sdk
```